### PR TITLE
Use fix namespace in policy exception

### DIFF
--- a/helm/debug-toolbox/templates/policy-exception.yaml
+++ b/helm/debug-toolbox/templates/policy-exception.yaml
@@ -3,7 +3,7 @@ apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ template "debug-toolbox.fullname" . }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: policy-exceptions
   labels:
     app: {{ template "debug-toolbox.fullname" . }}
   annotations:


### PR DESCRIPTION
Policy exception only can be created in certain namespaces